### PR TITLE
fix: also use display name on Message.username

### DIFF
--- a/src/classes/Message.ts
+++ b/src/classes/Message.ts
@@ -260,7 +260,9 @@ export class Message {
       this.masquerade?.name ??
       (webhook
         ? webhook.name
-        : (this.member?.nickname ?? this.author?.username))
+        : (this.member?.nickname ??
+          this.author?.displayName ??
+          this.author?.username))
     );
   }
 


### PR DESCRIPTION
This should fix stoatchat/for-web#1379 whenever the submodule is bumped.