### PR TITLE
fix: Normalize regex format

### DIFF
--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,17 +1,17 @@
 /**
  * Regular expression for mentions.
  */
-export const RE_MENTIONS = /<@([0-9ABCDEFGHJKMNPQRSTVWXYZ]{26})>/g;
+export const RE_MENTIONS = /<@([A-Z\d]{26})>/g;
 
 /**
  * Regular expression for channels.
  */
-export const RE_CHANNELS = /<#([0-9ABCDEFGHJKMNPQRSTVWXYZ]{26})>/g;
+export const RE_CHANNELS = /<#([A-Z\d]{26})>/g;
 
 /**
  * Regular expression for stripping custom emojis.
  */
-export const RE_CUSTOM_EMOJI = /:([0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}):/g;
+export const RE_CUSTOM_EMOJI = /:([A-Z\d]{26}):/g;
 
 /**
  * Regular expression for spoilers.

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,17 +1,17 @@
 /**
  * Regular expression for mentions.
  */
-export const RE_MENTIONS = /<@([A-Z\d]{26})>/g;
+export const RE_MENTIONS = /<@([ABCDEFGHJKMNPQRSTVWXYZ\d]{26})>/g;
 
 /**
  * Regular expression for channels.
  */
-export const RE_CHANNELS = /<#([A-Z\d]{26})>/g;
+export const RE_CHANNELS = /<#([ABCDEFGHJKMNPQRSTVWXYZ\d]{26})>/g;
 
 /**
  * Regular expression for stripping custom emojis.
  */
-export const RE_CUSTOM_EMOJI = /:([A-Z\d]{26}):/g;
+export const RE_CUSTOM_EMOJI = /:([ABCDEFGHJKMNPQRSTVWXYZ\d]{26}):/g;
 
 /**
  * Regular expression for spoilers.


### PR DESCRIPTION
Matches the ULID regex format with what for-web uses because I'm pedantic like that and y'all need to use RegEx properly (I need to de-duplicate some of the regex that does the same thing as these strings in for-web too later)