### PR TITLE
fix: sync relationship changes for users not in the local cache

### DIFF
--- a/src/events/v1.ts
+++ b/src/events/v1.ts
@@ -905,6 +905,10 @@ export async function handleEvent(
       break;
     }
     case "UserRelationship": {
+      // Live UserUpdate events are dropped for unknown users (see UserUpdate
+      // below), so make sure this user exists in the cache before delegating.
+      client.users.getOrCreate(event.user._id, event.user);
+
       handleEvent(
         client,
         {


### PR DESCRIPTION
<!-- Describe your changes -->

This was reported and root-caused against `stoatchat/for-web` (the web client that consumes this SDK as a submodule), see stoatchat/for-web#1504 for the original bug report and repro ("friends aren't synced up correctly between clients"). The root cause lives here in the SDK's event handling, not in the web client, so the fix belongs in this repo.

`UserRelationship` events are re-dispatched internally as `UserUpdate` events. The `UserUpdate` handler only applies changes to a user that's already in the local collection it looks the user up with `getOrPartial`, which returns `undefined` for an unknown id when `partials` is disabled (the default this SDK's clients use).

So a relationship change made on another client accepting/receiving a friend request, blocking, unblocking, removing a friend is silently dropped here if this client has never cached that user before. It stays out of sync until the next full `Ready` resync (e.g. a page reload), which hydrates users unconditionally via `getOrCreate`.

Fix: ensure the user exists in the collection via `getOrCreate` before delegating to `UserUpdate`, using the data already included in the `UserRelationship` event payload the same data `Ready` already uses to hydrate users on initial sync, so no extra request is introduced.

Related to stoatchat/for-web#1504. This won't automatically close that issue, since `for-web` vendors this package as a submodule and will need its `stoat.js` reference updated after this lands.

## How was this PR tested?

- [x] `prettier` and `eslint` pass on the changed file
- [x] `tsc --noEmit` passes
- [ ] Couldn't exercise this end-to-end against a live server/second
      client no way to trigger a real `UserRelationship` event
      without two authenticated sessions and an unknown-to-each-other
      user pair. Traced the fix against the `Ready` handler's
      equivalent `getOrCreate` path as the reference behavior.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
