### PR TITLE
fix: before decoding lastMessageID, check if it's 26 characters long

### DIFF
--- a/src/classes/Channel.ts
+++ b/src/classes/Channel.ts
@@ -285,7 +285,7 @@ export class Channel {
    * Time when the last message was sent
    */
   get lastMessageAt(): Date | undefined {
-    return this.lastMessageId
+    return this.lastMessageId && this.lastMessageId.length === 26
       ? new Date(decodeTime(this.lastMessageId))
       : undefined;
   }


### PR DESCRIPTION
Hopefully this solves stoatchat/for-web#1556's `DEC_TIME_MALFORMED` ULID error.

Weirdly enough, I can't seem to replicate this issue myself on the web app, I had to write my own test to ensure this fix works as intended.